### PR TITLE
Server side FirebaseApp Initialization

### DIFF
--- a/src/main/java/com/google/sps/startup/StartupShutdown.java
+++ b/src/main/java/com/google/sps/startup/StartupShutdown.java
@@ -22,6 +22,8 @@ public class StartupShutdown implements ServletContextListener
             .setDatabaseUrl("https://meltingpot-step-2020.firebaseio.com/")
             .build();
 
+            FirebaseApp.initializeApp(options);
+
             System.out.println("FirebaseApp initialized");
         } catch (IOException e) {
             System.out.println("IOException while initializing");

--- a/src/main/java/com/google/sps/startup/StartupShutdown.java
+++ b/src/main/java/com/google/sps/startup/StartupShutdown.java
@@ -1,0 +1,34 @@
+package com.google.sps.startup;
+
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.FirebaseApp;
+import com.google.auth.oauth2.GoogleCredentials;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.annotation.WebListener;
+import java.io.IOException;
+
+@WebListener
+public class StartupShutdown implements ServletContextListener
+{
+    @Override
+    public void contextInitialized(ServletContextEvent event)
+    {
+        System.out.println("Server starting up...");
+
+        try {
+            FirebaseOptions options = new FirebaseOptions.Builder()
+            .setCredentials(GoogleCredentials.getApplicationDefault())
+            .setDatabaseUrl("https://meltingpot-step-2020.firebaseio.com/")
+            .build();
+
+            System.out.println("FirebaseApp initialized");
+        } catch (IOException e) {
+            System.out.println("IOException while initializing");
+        }
+    }
+    public void contextDestroyed(ServletContextEvent event)
+    {
+        System.out.println("Server shutting down...");
+    }
+}

--- a/src/main/java/com/google/sps/startup/StartupShutdown.java
+++ b/src/main/java/com/google/sps/startup/StartupShutdown.java
@@ -27,6 +27,7 @@ public class StartupShutdown implements ServletContextListener
             System.out.println("FirebaseApp initialized");
         } catch (IOException e) {
             System.out.println("IOException while initializing");
+            e.printStackTrace();
         }
     }
     public void contextDestroyed(ServletContextEvent event)


### PR DESCRIPTION
Used a ServletContextListener to run the FirebaseApp initialization before all the servlets started up. The use of the try catch was necessary as java does not allow interface implementations to throw exceptions not declared in the interface itself. However, in order to properly handle the exception, we print the stack trace when we catch an exception.