### PR TITLE
Refactoring DBUtils for easier testing

### DIFF
--- a/src/main/java/com/google/sps/data/DBUtils.java
+++ b/src/main/java/com/google/sps/data/DBUtils.java
@@ -8,9 +8,24 @@ import com.google.firebase.cloud.FirestoreClient;
 import java.util.concurrent.ExecutionException;
 
 public class DBUtils {
-  private static final Firestore database = FirestoreClient.getFirestore();
-  private static final CollectionReference recipesReference = database.collection("recipes");
+  private static final Firestore actualDatabase = FirestoreClient.getFirestore();
+  private static final CollectionReference actualRecipesReference = actualDatabase.collection("recipes");
   private static final String DB_COMMENTS = "comment-collection";
+
+  private static Firestore database;
+  private static CollectionReference recipesReference;
+
+  public static void testModeWithParams(Firestore db, CollectionReference recipesRef) {
+    // Use this method to inject mock db and recipe reference when testing
+    // SHOULD ONLY BE USED IN TESTS
+    database = db;
+    recipesReference = recipesRef;
+  }
+
+  public static void productionMode() {
+    database = actualDatabase;
+    recipesReference = actualRecipesReference;
+  }
 
   public static Firestore db() {
     return database;

--- a/src/main/java/com/google/sps/startup/StartupShutdown.java
+++ b/src/main/java/com/google/sps/startup/StartupShutdown.java
@@ -8,12 +8,15 @@ import java.io.IOException;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
+import com.google.sps.meltingpot.data.DBUtils;
 
 @WebListener
 public class StartupShutdown implements ServletContextListener {
   @Override
   public void contextInitialized(ServletContextEvent event) {
     System.out.println("Server starting up...");
+
+    DBUtils.productionMode();
 
     try {
       FirebaseOptions options = new FirebaseOptions.Builder()


### PR DESCRIPTION
This will allow us to inject mocks of the db into DBUtils, which we can then control through mockito. This should make it much easier to develop tests for stuff using mocks like the following:
```
@Test
public void someTestMethod() {
  Firestore mockDB = mock(Firestore.class);
  CollectionReference mockRecipeRef = mock(CollectionReference.class);

  when(mockRecipeRef.someMethod()).thenReturn(stuff);
  ... other mock stuff you might need
  DBUtils.testModeWithParams(mockDB, mockRecipeRef);
  run method that is being tested
  verify / assert behaviour
}
```